### PR TITLE
Win32 support to build miner and keygen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,12 @@
  project(SimpleCoin)
 
  
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
+ if (WIN32)
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++latest")
+else()
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")    
+endif()
+
 set (CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
@@ -52,3 +57,10 @@ if (UNIX)
         target_link_libraries(txgen ${CONAN_LIBS} -lstdc++fs)
     endif()
 endif()
+
+if (WIN32)
+    add_executable(miner ${CORE_SOURCES} ${EXTERNAL_SOURCES} ./src/tools/miner.cpp)
+    add_executable(keygen ${CORE_SOURCES} ${EXTERNAL_SOURCES} ./src/tools/keygen.cpp)
+    target_link_libraries(miner ${CONAN_LIBS})
+    target_link_libraries(keygen ${CONAN_LIBS})
+endif() 

--- a/src/core/helpers.cpp
+++ b/src/core/helpers.cpp
@@ -12,6 +12,12 @@
 #include <string>
 #include <array>
 
+// windows port for popen/pclose 
+#ifdef WIN32
+#define popen _popen
+#define pclose _pclose
+#endif
+
 using namespace std;
 
 TransactionAmount BMB(double amount) {


### PR DESCRIPTION
Hi Sakul, here you have my PR to adapt your project to win32 and build keygen and miner.

Attached the binaries I obtain.

[win32_release_binaries.zip](https://github.com/mr-pandabear/panda-coin/files/7709628/win32_release_binaries.zip)

The steps required to build it under windows are exactly the same that you use. 

```
git clone https://github.com/mr-pandabear/panda-coin.git
cd panda-coin
git checkout stable
mkdir build
cd build
conan install ..
cd ..
cmake .

(once here I open my visual studio solution and build the 2 binaries using the IDE)

```

You just need a windows machine with Conan, Visual Studio 2019 or above.

Let me know if further help is required.

