### PR TITLE
use std::random_device to generate thread safe random values

### DIFF
--- a/src/core/crypto.cpp
+++ b/src/core/crypto.cpp
@@ -262,7 +262,7 @@ void mineHash(SHA256Hash target, unsigned char challengeSize, SHA256Hash& soluti
     do {
         hash_count++;
         *reinterpret_cast<uint64_t*>(concat.data() + 32) += 1;
-        SHA256Hash fullHash = SHA256Fast((const char*)concat.data(), concat.size());
+        SHA256Hash fullHash = SHA256((const char*)concat.data(), concat.size());
         bool found = checkLeadingZeroBits(fullHash, challengeSize);
         if (found && !aFound.load()) {
             aFound.store(true);

--- a/src/core/crypto.cpp
+++ b/src/core/crypto.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <atomic>
 #include <thread>
+#include <random>
 #include "../external/ed25519/ed25519.h" //https://github.com/orlp/ed25519
 #include "../external/sha256/sha2.hpp" 
 #include "../core/logger.hpp"
@@ -251,11 +252,13 @@ void mineHash(SHA256Hash target, unsigned char challengeSize, SHA256Hash& soluti
     // By @Shifu!
     vector<uint8_t> concat;
     uint64_t hash_count = 0;
+    std::random_device t_rand;
 
     concat.resize(2 * 32);
     for (size_t i = 0; i < 32; i++) concat[i] = target[i];
     // fill with random data for privacy (one cannot guess number of tries later)
-    for (size_t i = 32; i < 64; ++i) concat[i] = rand() % 256;
+    for (size_t i = 32; i < 64; ++i) concat[i] = t_rand() % 256;
+
     do {
         hash_count++;
         *reinterpret_cast<uint64_t*>(concat.data() + 32) += 1;


### PR DESCRIPTION
Previously used rand() function is not thread safe. While it was working as wanted on Linux, it didn't generate random values on Windows. As a result all threads were calculating same hashes from same base values.

Using std::random_device fixes this problem as it it thread safe on all platforms.

I switched SHA256Fast back to SHA256 due to https://en.wikipedia.org/wiki/Intel_SHA_extensions. Maybe could be beneficial to have SHA256Fast for older cpus without extension support?